### PR TITLE
Update lsp-ws-proxy to v0.2.0

### DIFF
--- a/examples/demo-rust/package.json
+++ b/examples/demo-rust/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "rimraf public/js && webpack",
-    "start-ls-rust": "PATH=$(pwd)/bin:$PATH lsp-ws-proxy --port 9999 -- rust-analyzer",
+    "start-ls-rust": "PATH=$(pwd)/bin:$PATH lsp-ws-proxy -l 9999 -- rust-analyzer",
     "start": "pnpm build && concurrently \"pnpm start-ls-rust\" \"serve -l 4000 public\""
   },
   "dependencies": {

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "build": "rimraf public/js && webpack",
-    "start-ls-ts": "lsp-ws-proxy --port 9990 -- typescript-language-server --stdio",
-    "start-ls-html": "lsp-ws-proxy --port 9991 -- html-languageserver --stdio",
-    "start-ls-css": "lsp-ws-proxy --port 9992 -- css-languageserver --stdio",
+    "start-ls-ts": "lsp-ws-proxy -l 9990 -- typescript-language-server --stdio",
+    "start-ls-html": "lsp-ws-proxy -l 9991 -- html-languageserver --stdio",
+    "start-ls-css": "lsp-ws-proxy -l 9992 -- css-languageserver --stdio",
     "start": "pnpm build && concurrently \"pnpm start-ls-ts\" \"pnpm start-ls-html\" \"pnpm start-ls-css\" \"serve -l 4000 public\""
   },
   "dependencies": {


### PR DESCRIPTION
Command line option changed from `--port` to `--listen` to accept address like `0.0.0.0:9999` in addition to a port number.

See [v0.2.0].

[v0.2.0]: https://github.com/qualified/lsp-ws-proxy/releases/tag/v0.2.0