### PR TITLE
Add `willSave` and `willSaveWaitUntil` capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ See [examples/demo](./examples/demo) for a simple demo project with TypeScript +
   - `didChange` ![ok]
     - Full text change ![ok]
     - Incremental text change ![ok]
-  - `willSave` ![no]
-  - `willSaveWaitUntil` ![no]
+  - `willSave` ![meh]
+  - `willSaveWaitUntil` ![meh]
   - `didSave` ![meh]
   - `didClose` ![ok]
 - `completion`

--- a/examples/demo-save/src/main.ts
+++ b/examples/demo-save/src/main.ts
@@ -89,6 +89,11 @@ const workspace = new Workspace({
 const documentUri = rootUri + "/src/main.rs";
 workspace.openTextDocument(documentUri, rustEditor);
 
-document.getElementById("save")!.addEventListener("click", () => {
-  workspace.saveTextDocument(documentUri);
+const button = document.getElementById("save")!;
+button.addEventListener("click", async () => {
+  button.textContent = "Saving...";
+  button.setAttribute("disabled", "");
+  await workspace.saveTextDocument(documentUri);
+  button.removeAttribute("disabled");
+  button.textContent = "Save";
 });

--- a/packages/codemirror-workspace/src/utils/promise.ts
+++ b/packages/codemirror-workspace/src/utils/promise.ts
@@ -1,0 +1,1 @@
+export const delay = (ms: number) => new Promise((f) => setTimeout(f, ms));


### PR DESCRIPTION
Note that these are not tested at all and we might end up removing if it turns out not useful. I wrote these while reading the spec and thinking what's necessary to support them. 

I originally thought `TextEdit[]` from `willSaveWaitUntil` request is used to implement format on save, but it doesn't seem like it because `rust-analyzer` doesn't support this capability.
In fact, I don't have a server with this capability to test against.