### PR TITLE
Adds manual autocompletion shortcut

### DIFF
--- a/.changeset/cold-fireants-trade.md
+++ b/.changeset/cold-fireants-trade.md
@@ -1,0 +1,5 @@
+---
+"@qualified/codemirror-workspace": patch
+---
+
+Adds manual autocompletion shortcut


### PR DESCRIPTION
- Currently just `CTRL-Space`, we might want to add a few others (e.g., CMD-Space?)
- Need to figure out how to expose more of these on the workspace or editor

We might be able to make this a lot cleaner and more customizable later using [CodeMirror commands](https://codemirror.net/doc/manual.html#commands), especially for things that are defined in key maps.

However, this requires us to be able to trigger events only knowing the `editor`, and not any other information.

Closes QP-5989