### PR TITLE
Improves tooltip experience by closing when mouse leaves editor

### DIFF
--- a/.changeset/loud-dogs-argue.md
+++ b/.changeset/loud-dogs-argue.md
@@ -1,0 +1,5 @@
+---
+"@qualified/codemirror-workspace": patch
+---
+
+Improves tooltip experience by closing when mouse leaves editor

--- a/packages/codemirror-workspace/src/capabilities/hover.ts
+++ b/packages/codemirror-workspace/src/capabilities/hover.ts
@@ -3,6 +3,7 @@ import type { Hover } from "vscode-languageserver-protocol";
 
 import { addTooltip } from "../ui/tooltip";
 import { cmRange, hoverContentsToString } from "../utils/conversions";
+import { MouseLeaveAllListener } from "../events";
 
 const states = new WeakMap<Editor, LspHoverState>();
 
@@ -10,17 +11,20 @@ interface LspHoverState {
   marker?: TextMarker;
   tooltip?: HTMLElement;
   disabled?: boolean;
+  mouseLeaveAllListener?: MouseLeaveAllListener;
 }
 
 /**
  * Show hover information.
  * @param editor
+ * @param mouseLeaveAllListener
  * @param pos Position of the event
  * @param hover
  * @param renderMarkdown
  */
 export const showHoverInfo = (
   editor: Editor,
+  mouseLeaveAllListener: MouseLeaveAllListener,
   pos: Position,
   hover: Hover,
   renderMarkdown: (x: string) => string = (x) => x
@@ -44,6 +48,8 @@ export const showHoverInfo = (
   el.innerHTML = info;
   const coords = editor.charCoords(start, "page");
   state.tooltip = addTooltip(el, coords.left, coords.top);
+  state.mouseLeaveAllListener = mouseLeaveAllListener;
+  mouseLeaveAllListener.addElement(state.tooltip);
   states.set(editor, state);
 };
 
@@ -56,6 +62,8 @@ export const removeHoverInfo = (editor: Editor) => {
   if (!state) return;
 
   if (state.marker) state.marker.clear();
+  if (state.mouseLeaveAllListener && state.tooltip)
+    state.mouseLeaveAllListener.removeElement(state.tooltip);
   if (state.tooltip) state.tooltip.remove();
   states.delete(editor);
 };

--- a/packages/codemirror-workspace/src/events.ts
+++ b/packages/codemirror-workspace/src/events.ts
@@ -1,6 +1,6 @@
 import type { Editor, EditorChange } from "codemirror";
-import type { Stream, Disposer } from "./utils/event-stream";
 import { signal as cmSignal } from "codemirror";
+import type { Disposer, Stream } from "./utils/event-stream";
 
 export interface EditorEventMap {
   changes: [cm: Editor, changes: EditorChange[]];
@@ -52,3 +52,89 @@ export const signal = <K extends keyof EditorEventMap>(
 ) => {
   cmSignal(editor, name, ...args);
 };
+
+/**
+ * Internal object for tracking individual elements and their event listeners
+ */
+export interface MouseLeaveAllListenerItem {
+  over: boolean;
+  element: HTMLElement;
+  onEnter: EventListenerOrEventListenerObject;
+  onLeave: EventListenerOrEventListenerObject;
+}
+
+/**
+ * Special class for listening to enter/leave events on a group of elements. When none of those elements are
+ * being hovered over, a callback is triggered.
+ */
+export class MouseLeaveAllListener {
+  private listeners: MouseLeaveAllListenerItem[];
+  private onMouseLeaveAll: Function;
+
+  /**
+   * @param onMouseLeaveAll - Called when none of the tracked elements have a mouse over them.
+   */
+  constructor(onMouseLeaveAll: Function) {
+    this.onMouseLeaveAll = onMouseLeaveAll;
+    this.listeners = [];
+  }
+
+  /**
+   * Adds an element to the list of tracked elements.
+   * This element will have mouseenter and mouseleave events tracked.
+   * @param element
+   */
+  addElement(element: HTMLElement) {
+    if (this.listeners.find((l) => l.element === element)) return;
+    const l = {
+      element,
+      over: false,
+      onEnter: () => {
+        l.over = true;
+      },
+      onLeave: () => {
+        l.over = false;
+        this.checkHoverState();
+      },
+    };
+    this.listeners.push(l);
+    element.addEventListener("mouseenter", l.onEnter);
+    element.addEventListener("mouseleave", l.onLeave);
+  }
+
+  /**
+   * Removes an element from the list of tracked elements.
+   * If the element is found, we also remove the event listeners.
+   * @param element
+   * @return {boolean} - true if the element was found, false otherwise
+   */
+  removeElement(element: HTMLElement) {
+    const idx = this.listeners.findIndex((l) => l.element === element);
+    const found = idx !== -1;
+    if (found) {
+      const l = this.listeners[idx];
+      this.listeners.splice(idx, 1);
+      l.element.removeEventListener("mouseenter", l.onEnter);
+      l.element.removeEventListener("mouseleave", l.onLeave);
+      this.checkHoverState();
+    }
+    return found;
+  }
+
+  /**
+   * Removes all tracked elements from this class.
+   */
+  dispose() {
+    this.listeners.forEach((l) => {
+      this.removeElement(l.element);
+    });
+  }
+
+  private checkHoverState() {
+    window.setTimeout(() => {
+      if (this.listeners.every((el) => !el.over)) {
+        this.onMouseLeaveAll();
+      }
+    }, 500);
+  }
+}


### PR DESCRIPTION
- Added a new class to listen for mouse enter/leave events on a collection of elements
  - When the mouse leaves _all_ of the watched elements, we call a function
- This allows us to detect when the mouse is no longer above either the main editor _or_ a tooltip/popover.
  - I chose not to listen to either code completion or context menu events for now, since it didn't seem necessary

@kazk I determined I couldn't make the popups children of the editor node, because they get cut off by the `overflow: hidden`. However, this seems to work pretty well, and I'm happy with the class I came up with.

Closes QP-6008