### PR TITLE
Add `CancellationToken` parameter to requests

### DIFF
--- a/.changeset/rude-hats-leave.md
+++ b/.changeset/rude-hats-leave.md
@@ -1,0 +1,5 @@
+---
+"@qualified/lsp-connection": patch
+---
+
+Add `CancellationToken` parameter to requests

--- a/packages/lsp-connection/src/connection.ts
+++ b/packages/lsp-connection/src/connection.ts
@@ -2,6 +2,7 @@ import type {
   Message,
   MessageConnection,
   NotificationHandler,
+  CancellationToken,
 } from "vscode-jsonrpc";
 import type {
   InitializeParams,
@@ -76,8 +77,11 @@ export const createLspConnection = (conn: MessageConnection) => {
   const maybeReq = <T extends ProtocolRequestType<any, any, any, any, any>>(
     cond: () => boolean,
     type: T
-  ) => (params: Params<T>): Promise<Result<T> | null> =>
-    cond() ? conn.sendRequest(type, params) : Promise.resolve(null);
+  ) => (
+    params: Params<T>,
+    token?: CancellationToken
+  ): Promise<Result<T> | null> =>
+    cond() ? conn.sendRequest(type, params, token) : Promise.resolve(null);
 
   const maybeNotify = <T extends ProtocolNotificationType<any, any>>(
     cond: () => boolean,


### PR DESCRIPTION
```typescript
const cts = new CancellationTokenSource();
conn
  .getCompletion({ textDocument, position, context }, cts.token)
  .then((items) => {
    // ...
  });
setTimeout(() => cts.cancel(), 500);
```
The server cancels the request, and responds with a partial or empty result.