### PR TITLE
Adds close button to popups

### DIFF
--- a/.changeset/wicked-ligers-repeat.md
+++ b/.changeset/wicked-ligers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@qualified/codemirror-workspace": minor
+---
+
+Added close button to tooltips

--- a/packages/codemirror-workspace/css/default.css
+++ b/packages/codemirror-workspace/css/default.css
@@ -133,11 +133,47 @@
   border: 1px solid #495057;
   border-radius: 2px;
   font-family: sans-serif;
-  font-size: 14px;
-  padding: 0;
+  font-size: 12px;
+  padding: 2px;
+  z-index: 10;
+  position: absolute;
+  max-width: 50ch;
+  max-height: 120px;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
     0 2px 4px -1px rgba(0, 0, 0, 0.06);
 }
+.cmw-tooltip > div {
+  overflow-y: auto;
+}
+.cmw-tooltip .cmw-tooltip-close {
+  position: absolute;
+  top: -8px;
+  right: -12px;
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  opacity: 0;
+  padding: 2px;
+  transition: opacity 0.1s ease-in-out;
+}
+.cmw-tooltip .cmw-tooltip-close::before {
+  content: "×";
+  display: block;
+  width: 14px;
+  height: 14px;
+  font-size: 12px;
+  line-height: 14px;
+  text-align: center;
+  border-radius: 8px;
+  background-color: #495057;
+  color: #f8f9fa;
+}
+.cmw-tooltip:hover .cmw-tooltip-close,
+.cmw-tooltip:focus .cmw-tooltip-close,
+.cmw-tooltip-close:hover {
+  opacity: 1;
+}
+
 /* Markdown */
 .cmw-completion-item-doc pre,
 .cmw-tooltip pre,

--- a/packages/codemirror-workspace/src/ui/tooltip.ts
+++ b/packages/codemirror-workspace/src/ui/tooltip.ts
@@ -5,18 +5,14 @@ export const addTooltip = (
 ) => {
   const tooltip = document.createElement("div");
   tooltip.classList.add("cmw-tooltip");
-  tooltip.style.cssText = [
-    "font-size: 12px;",
-    "padding: 2px;",
-    "z-index: 10;",
-    "position: absolute;",
-    `left: ${x}px;`,
-    `top: ${y}px;`,
-    `max-width: 50ch;`,
-    `max-height: 120px;`,
-    `overflow-y: auto;`,
-  ].join(" ");
+  tooltip.style.cssText = [`left: ${x}px;`, `top: ${y}px;`].join(" ");
   tooltip.appendChild(tooltipContent);
+  const close = document.createElement("div");
+  close.classList.add("cmw-tooltip-close");
+  close.addEventListener("click", () => {
+    tooltip.remove();
+  });
+  tooltip.appendChild(close);
   document.body.appendChild(tooltip);
 
   // Make sure that the tooltip is above the text even when it's multiline.


### PR DESCRIPTION
- This basically is a CYA for when popups get stuck.
- By default, the close button is hidden. When you hover over the tooltip, the close button is revealed.
- Clicking the close button removes the DOM node from the page
- I also moved most of the hard-coded styles for the tooltip (everything except X/Y) into the CSS for better control and overriding

<img width="312" alt="Screen Shot 2022-01-04 at 11 16 14 AM" src="https://user-images.githubusercontent.com/965719/148089593-94c300b2-e262-4e7d-892b-bb073d495da8.png">


Closes QP-6071