### PR TITLE
Provides the ability to disable all popups

### DIFF
--- a/.changeset/violet-cows-tie.md
+++ b/.changeset/violet-cows-tie.md
@@ -1,0 +1,6 @@
+---
+"@qualified/codemirror-workspace-demo": minor
+"@qualified/codemirror-workspace": minor
+---
+
+Added the ability to disable all popups temporarily

--- a/examples/demo/public/index.html
+++ b/examples/demo/public/index.html
@@ -15,6 +15,10 @@
         margin: 0 auto;
         max-width: 80ch;
       }
+      .buttons {
+        margin: 0 auto;
+        text-align: center;
+      }
     </style>
   </head>
   <body>
@@ -24,6 +28,11 @@
       <div id="html-editor" class="editor"></div>
       <div id="css-editor" class="editor"></div>
     </div>
+
+    <div class="buttons">
+          <button id="enablePopups">Enable Popups</button>
+          <button id="disablePopups">Disable Popups</button>
+        </div>
 
     <script src="js/main.js"></script>
   </body>

--- a/examples/demo/src/main.ts
+++ b/examples/demo/src/main.ts
@@ -130,3 +130,12 @@ workspace.openTextDocument("add.ts", tsEditorAdd);
 workspace.openTextDocument("source.ts", tsEditorSource);
 workspace.openTextDocument("project.html", htmlEditor);
 workspace.openTextDocument("style.css", cssEditor);
+
+const enablePopupsButton = document.getElementById("enablePopups")!;
+enablePopupsButton.addEventListener("click", () => {
+  workspace.enablePopups(true);
+});
+const disablePopupsButton = document.getElementById("disablePopups")!;
+disablePopupsButton.addEventListener("click", () => {
+  workspace.enablePopups(false);
+});


### PR DESCRIPTION
- Adds new `enablePopups()` method to workspace
- Adds new `popupsEnabled` property that is used to bypass showing popups (while continuing to leave workspace enabled and running)
- Adds buttons to demo to test enabling or disabling popups


@kazk I need this for the PCC Interact, because we don't want to show popups to users who are not the active editor (it's confusing and also they get stuck). I could have left hover commands enabled, but I don't think that the distinction is necessary.